### PR TITLE
♻️ refactor: rename symbols to fix duplicate symbols compile errors while building iOS App

### DIFF
--- a/ios/NSData+DataPtr.m
+++ b/ios/NSData+DataPtr.m
@@ -11,7 +11,7 @@
 
 + (NSData *)fromDataPtr:(DataPtr *)ptr {
     NSData* data = [NSData dataWithBytes:ptr->ptr length:ptr->len];
-    dataptr_free(ptr);
+    msl_dataptr_free(ptr);
     return data;
 }
 

--- a/ios/NSString+RPtr.m
+++ b/ios/NSString+RPtr.m
@@ -16,7 +16,7 @@
 
 + (NSString *)stringFromCharPtr:(CharPtr *)ptr {
     NSString* str = [NSString stringWithUTF8String:*ptr];
-    charptr_free(ptr);
+    msl_charptr_free(ptr);
     return str;
 }
 

--- a/rust/src/ios/bridge_tools/data.rs
+++ b/rust/src/ios/bridge_tools/data.rs
@@ -6,7 +6,7 @@ pub struct DataPtr {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn free_data_ptr(data_ptr: &mut DataPtr) {
+pub unsafe extern "C" fn msl_free_data_ptr(data_ptr: &mut DataPtr) {
   data_ptr.free();
 }
 
@@ -54,6 +54,6 @@ impl <T:From<T>> IntoOptionDataPtr for Option<T> where DataPtr: From<T>{
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dataptr_free(data: &mut DataPtr) {
+pub unsafe extern "C" fn msl_dataptr_free(data: &mut DataPtr) {
   data.free();
 }

--- a/rust/src/ios/bridge_tools/string.rs
+++ b/rust/src/ios/bridge_tools/string.rs
@@ -58,7 +58,7 @@ impl IntoOptionalCString for Option<String> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn charptr_free(ptr: &mut CharPtr) {
+pub unsafe extern "C" fn msl_charptr_free(ptr: &mut CharPtr) {
   let _ = CString::from_raw(*ptr as *mut c_char);
   *ptr = std::ptr::null_mut();
 }


### PR DESCRIPTION
Fix:

```
duplicate symbol '_charptr_free' in: ...
duplicate symbol '_free_data_ptr' in: ...
duplicate symbol '_dataptr_free' in: ...
ld: 3 duplicate symbols for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```